### PR TITLE
Fix new Instagram CSS, firefox path problems and installation glitches

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,11 @@ There are 2 packages : selenium & requests
 ```
 $ pip install -r requirements.txt
 ```
+
+###### Optional: geckodriver and phantomjs if not present on your system
+```
+bash utils/get_gecko.sh
+bash utils/get_phantomjs.sh
+source utils/set_path.sh
+```
+

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ usage: instagramcrawler.py [-h] [-d DIR] [-q QUERY] [-t CRAWL_TYPE] [-n NUMBER] 
   - [-c]: add this flag to download captions(what user wrote to describe their photos)
   - [-a AUTHENTICATION]: path to a json file, which contains your instagram credentials, please see 'auth.json'
   - [-l HEADLESS]: If set, will use PhantomJS driver to run script as headless
+  - [-f FIREFOX_PATH]: path to the **binary** (not the script) of firefox on your system (see this issue in Selenium https://github.com/SeleniumHQ/selenium/issues/3884#issuecomment-296988595)
 
 
 ### Installation

--- a/instagramcrawler.py
+++ b/instagramcrawler.py
@@ -28,7 +28,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 HOST = 'http://www.instagram.com'
 
 # SELENIUM CSS SELECTOR
-CSS_LOAD_MORE = "a._8imhp._glz1g"
+CSS_LOAD_MORE = "a._1cr2e._epyes"
 CSS_RIGHT_ARROW = "a[class='_de018 coreSpriteRightPaginationArrow']"
 FIREFOX_FIRST_POST_PATH = "//div[contains(@class, '_8mlbc _vbtk2 _t5r8b')]"
 TIME_TO_CAPTION_PATH = "../../../div/ul/li/span"

--- a/instagramcrawler.py
+++ b/instagramcrawler.py
@@ -18,6 +18,7 @@ except ImportError:
 import requests
 import selenium
 from selenium import webdriver
+from selenium.webdriver.firefox.firefox_binary import FirefoxBinary
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.common.exceptions import NoSuchElementException, TimeoutException
@@ -59,12 +60,14 @@ class InstagramCrawler(object):
     """
         Crawler class
     """
-    def __init__(self, headless=True):
+    def __init__(self, headless=True, firefox_path=None):
         if headless:
             print("headless mode on")
             self._driver = webdriver.PhantomJS()
         else:
-            self._driver = webdriver.Firefox()
+            # credit to https://github.com/SeleniumHQ/selenium/issues/3884#issuecomment-296990844
+            binary = FirefoxBinary(firefox_path)
+            self._driver = webdriver.Firefox(firefox_binary=binary)
 
         self._driver.implicitly_wait(10)
         self.data = defaultdict(list)
@@ -339,10 +342,12 @@ def main():
                         help='If set, will use PhantomJS driver to run script as headless')
     parser.add_argument('-a', '--authentication', type=str, default=None,
                         help='path to authentication json file')
+    parser.add_argument('-f', '--firefox_path', type=str, default=None,
+                        help='path to Firefox installation')
     args = parser.parse_args()
     #  End Argparse #
 
-    crawler = InstagramCrawler(headless=args.headless)
+    crawler = InstagramCrawler(headless=args.headless, firefox_path=args.firefox_path)
     crawler.crawl(dir_prefix=args.dir_prefix,
                   query=args.query,
                   crawl_type=args.crawl_type,

--- a/utils/get_gecko.sh
+++ b/utils/get_gecko.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# following travis.yml https://github.com/iammrhelo/InstagramCrawler/blob/master/.travis.yml#L11-L14
+
+wget https://github.com/mozilla/geckodriver/releases/download/v0.16.0/geckodriver-v0.16.0-linux64.tar.gz
+mkdir -p geckodriver && tar zxvf geckodriver-v0.16.0-linux64.tar.gz -C geckodriver
+

--- a/utils/get_phantomjs.sh
+++ b/utils/get_phantomjs.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# from https://stackoverflow.com/a/45273545/470341
+
+wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2
+tar xvjf phantomjs-2.1.1-linux-x86_64.tar.bz2
+

--- a/utils/set_path.sh
+++ b/utils/set_path.sh
@@ -1,0 +1,4 @@
+
+PATH=${PATH}:${PWD}/geckodriver
+PATH=${PATH}:${PWD}/phantomjs-2.1.1-linux-x86_64/bin
+


### PR DESCRIPTION
This PR solves various issues:
  - [X] allows to circumvent issue #5 from the command line by specify the path to the firefox binary on the system (not the script)
  - [X] fix #13 due to a change in Instagram's CSS (and potentially other timeout exceptions? #4? #10?)
  - [X] provides simple scripts to install binary dependencies and add them to the `PATH`
     - `geckodriver` (fix #15)
     - `phantomjs` (on ubuntu/debian, packaged version is not working)
  - [X] updates the [`README`](https://github.com/iammrhelo/InstagramCrawler/blob/master/README.md) with new features