### PR TITLE
reworking how total post count is pulled from page; fixes issue #26

### DIFF
--- a/instagramcrawler.py
+++ b/instagramcrawler.py
@@ -157,18 +157,15 @@ class InstagramCrawler(object):
 
     def scroll_to_num_of_posts(self, number):
         # Get total number of posts of page
-        num_info = re.search(r'\], "count": \d+',
-                             self._driver.page_source).group()
-        num_of_posts = int(re.findall(r'\d+', num_info)[0])
+        # instagram returns a number like u'70,478,137'
+        num_re = re.search(r'([\d,]+)\s*</span>\s*posts\s*<\/span>',
+                            self._driver.page_source)
+        if num_re:
+            num_of_posts = int(num_re.groups()[0].replace(',',''))
+        else:
+            print("failed to parse number of posts of page")
         print("posts: {}, number: {}".format(num_of_posts, number))
         number = number if number < num_of_posts else num_of_posts
-
-        # scroll page until reached
-        loadmore = WebDriverWait(self._driver, 10).until(
-            EC.presence_of_element_located(
-                (By.CSS_SELECTOR, CSS_LOAD_MORE))
-        )
-        loadmore.click()
 
         num_to_scroll = int((number - 12) / 12) + 1
         for _ in range(num_to_scroll):


### PR DESCRIPTION
instagram has changed the format of the page; it no longer has a `CSS_LOAD_MORE` that I can detect so I removed that as well. I can now use this command successfully:

```
$ python instagramcrawler.py -q '#breakfast' -n 5
dir_prefix: ./data/, query: #breakfast, crawl_type: photos, number: 5, caption: False, authentication: None
posts: 70478766, number: 5
Scraping photo links...
Number of photo_links: 33
Saving...
Downloading 5 images to ata/breakfast.hashtag
Quitting driver...
```

using geckodriver 0.20.0 for osx:
> https://github.com/mozilla/geckodriver/releases/download/v0.20.0/geckodriver-v0.20.0-macos.tar.gz
